### PR TITLE
Removed mapping log levens warn and err to warning and error

### DIFF
--- a/lib/winston-logentries.js
+++ b/lib/winston-logentries.js
@@ -26,7 +26,6 @@ Logentries = (function(superClass) {
 
   Logentries.prototype.log = function(level, msg, meta, callback) {
     var data;
-    level = this.remapLevels(level);
     if (meta != null) {
       meta = JSON.stringify(meta);
       meta = meta === '{}' ? '' : " " + meta;
@@ -34,16 +33,6 @@ Logentries = (function(superClass) {
     data = msg + meta;
     this.logentries.log(level, data);
     return callback(null, true);
-  };
-
-  Logentries.prototype.remapLevels = function(level) {
-    if (level === 'warn') {
-      return 'warning';
-    }
-    if (level === 'error') {
-      return 'err';
-    }
-    return level;
   };
 
   return Logentries;

--- a/src/winston-logentries.coffee
+++ b/src/winston-logentries.coffee
@@ -11,7 +11,6 @@ class Logentries extends winston.Transport
     @logentries.level @level
 
   log: (level, msg, meta, callback) ->
-    level = @remapLevels level
 
     if meta?
       meta = JSON.stringify meta
@@ -20,11 +19,6 @@ class Logentries extends winston.Transport
     data = msg + meta
     @logentries.log level, data
     callback null, true
-
-  remapLevels: (level) ->
-    return 'warning' if level is 'warn'
-    return 'err' if level is 'error'
-    level
 
 winston.transports.Logentries = Logentries
 

--- a/test/winston-logentries.spec.coffee
+++ b/test/winston-logentries.spec.coffee
@@ -70,8 +70,8 @@ describe 'Logentries log levels', ->
 
   it 'calls `log` method with `warning` level which has been translated from  `warn`', ->
     logger.warn 'hello!', foo: 123
-    expect(transport.logentries.log).to.have.been.calledWith 'warning', 'hello! {"foo":123}'
+    expect(transport.logentries.log).to.have.been.calledWith 'warn', 'hello! {"foo":123}'
 
   it 'calls `log` method with `err` level which has been translated from  `error`', ->
     logger.error 'hello!', foo: 123
-    expect(transport.logentries.log).to.have.been.calledWith 'err', 'hello! {"foo":123}'
+    expect(transport.logentries.log).to.have.been.calledWith 'error', 'hello! {"foo":123}'


### PR DESCRIPTION
Logentries.com changed their log levels from "warning" and "err" to "warn" and "error". This PR removes the internal mapping that fixed logentries' previous weird naming.
